### PR TITLE
fixes invite codes

### DIFF
--- a/lib/ui/modals.js
+++ b/lib/ui/modals.js
@@ -5,6 +5,7 @@ var app = require('../app')
 var ui = require('./index')
 var com = require('../com')
 var social = require('../social-graph')
+var ref = require('ssb-ref')
 
 function modal (el) {
   // create a context so we can release this modal on close
@@ -87,7 +88,6 @@ module.exports.prompt = function (text, placeholder, submitText, cb) {
   return m
 }
 
-var inviteRegex = /.+:.+:.+@.+/
 module.exports.invite = function (e) {
   e.preventDefault()
 
@@ -108,7 +108,7 @@ module.exports.invite = function (e) {
     if (code.charAt(0) == '"' && code.charAt(code.length - 1) == '"')
       code = code.slice(1, -1) // strip em
 
-    if (inviteRegex.test(code)) {
+    if (ref.isInvite(code)) {
       form.setProcessingText('Contacting server with invite code, this may take a few moments...')
       app.ssb.invite.accept(code, addMeNext)
     }
@@ -125,7 +125,7 @@ module.exports.invite = function (e) {
       }
 
       // trigger sync with the pub
-      app.ssb.gossip.connect(code.split(',')[0])
+      app.ssb.gossip.connect(code.split('~')[0])
 
       // nav to home in live-party-mode
       m.close()
@@ -226,7 +226,7 @@ module.exports.getLookup = function (e) {
     var addrs = []
     peers.forEach(function (peer) {
       if (social.follows(peer.key, app.user.id))
-        addrs.push(peer.host + ':' + peer.port + ':' + peer.key)
+        addrs.push(peer.host + ':' + peer.port + ':' + (peer.key || peer.link))
     })
     var code = app.user.id
     if (addrs.length)

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ssb-manifest": "^1.1.1",
     "ssb-msg-schemas": "~5.0.0",
     "ssb-msgs": "~5.0.0",
-    "ssb-ref": "~2.0.0",
+    "ssb-ref": "~2.2.0",
     "stream-to-pull-stream": "~1.6.0",
     "suggest-box": "~1.1.6"
   },


### PR DESCRIPTION
this uses a tested invite checker from ssb-ref instead of a inline regex.

I found another bug behind this. when you use the invite, it appears to successfully replicate, but does not display any notifications on the ui. I have to restart patchwork to see my feed. This is the part we really need to get right, because we need the wow factor of suddenly being in the network.