### PR TITLE
make posting tab+ENTER by default

### DIFF
--- a/lib/com/post-form.js
+++ b/lib/com/post-form.js
@@ -41,8 +41,8 @@ module.exports = function (rootMsg, branchMsg, opts) {
     h('.post-form-textarea', textarea),
     previewEl,
     h('.post-form-attachments.hidden',
-      (!isSecret) ? h('a', { href: '#', onclick: addFile }, 'Click here to add an attachment') : '',
       postBtn,
+      (!isSecret) ? h('a', { href: '#', onclick: addFile }, 'Click here to add an attachment') : '',
       filesInput
     )
   )


### PR DESCRIPTION
changes the default posting behaviour to : `tab, ENTER`

(currently it's `tab, tab, ENTER`, which drives me CRAZY)

have hard-coded the change in my node-modules of patchwork and can confirm it doesn't change layout because blocks are `position: absolute` etc